### PR TITLE
cuda-visual-tools v13.1.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,10 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-2
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-2
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.1.0" %}
+{% set version = "13.1.1" %}
 
 package:
   name: cuda-visual-tools
@@ -14,9 +14,9 @@ build:
 
 requirements:
   run:
-    - cuda-nsight 13.1.68               # [linux64]
-    - nsight-compute 2025.4.0.12
-    - cuda-nvml-dev 13.1.68
+    - cuda-nsight 13.1.115               # [linux64]
+    - nsight-compute 2025.4.1.2
+    - cuda-nvml-dev 13.1.115
     - cuda-libraries-dev {{ version }}
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.0.2" %}
+{% set version = "13.1.0" %}
 
 package:
   name: cuda-visual-tools
@@ -14,9 +14,9 @@ build:
 
 requirements:
   run:
-    - cuda-nsight 13.0.85               # [linux64]
-    - nsight-compute 2025.3.1.4
-    - cuda-nvml-dev 13.0.87
+    - cuda-nsight 13.1.68               # [linux64]
+    - nsight-compute 2025.4.0.12
+    - cuda-nvml-dev 13.1.68
     - cuda-libraries-dev {{ version }}
 
 test:


### PR DESCRIPTION
cuda-visual-tools 13.1.1

**Destination channel:** defaults

### Links

- [PKG-12038](https://anaconda.atlassian.net/browse/PKG-12038) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12038]: https://anaconda.atlassian.net/browse/PKG-12038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ